### PR TITLE
Add C Files from aws_guru_c_detector_library_samples - Batch 02

### DIFF
--- a/detectors/incorrect-use-of-free/compliant.c
+++ b/detectors/incorrect-use-of-free/compliant.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-of-free@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int incorrectUseOfFreeCompliant() {
+    NAME *var;
+    char buf[10];
+    var = (NAME *)malloc(sizeof(struct name));
+    free(var);
+    var = (NAME *)malloc(sizeof(struct name));
+    // Compliant: Variable is used after memory reallocation
+    var->func(var->myname);
+    return 0;
+}
+
+// {/fact}

--- a/detectors/insecure-temporary-file-or-directory/compliant.c
+++ b/detectors/insecure-temporary-file-or-directory/compliant.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <unistd.h>
+
+int insecureTemporaryFileorDirectoryCompliant(char *tempData) {
+  // Compliant: The file will be opened in "wb+" mode, and will be automatically removed on normal program exit
+  FILE* f = tmpfile(); 
+  fputs(tempData, f);
+  fclose(f);
+  return 0;
+}
+// {/fact}

--- a/detectors/insecure-temporary-file-or-directory/non-compliant.c
+++ b/detectors/insecure-temporary-file-or-directory/non-compliant.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <unistd.h>
+
+int insecureTemporaryFileorDirectoryNonCompliant(char *tempData) {
+  // Noncompliant: Insecure function used
+  char *path = tmpnam(NULL); 
+  FILE* f = fopen(path, "w");
+  fputs(tempData, f);
+  fclose(f);
+}
+// {/fact}

--- a/detectors/loose-file-permissions/compliant.c
+++ b/detectors/loose-file-permissions/compliant.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=loose-file-permissions@v1.0 defects=0}
+#include <sys/stat.h>
+#include <fcntl.h>
+
+void looseFilePermissionsCompliant(){
+  
+  int fd;
+
+  // Compliant: The O_CREAT flag indicates that the file should be created if it doesn't exist.
+  open("myfile.txt", O_CREAT, S_IRWXU | S_IRWXG); 
+  // Compliant: further created files or directories will not have permissions set for "other group"
+  umask(S_IRWXO); 
+  
+}
+// {/fact}

--- a/detectors/loose-file-permissions/non-compliant.c
+++ b/detectors/loose-file-permissions/non-compliant.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=loose-file-permissions@v1.0 defects=1}
+#include <sys/stat.h>
+#include <fcntl.h>
+
+void looseFilePermissionsNonCompliant(){
+
+  int fd;
+
+  // Noncompliant: The process set 777 permissions to this newly created file
+  open("myfile.txt", O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO); 
+
+  // Noncompliant: The process try to set 777 permissions to this newly created directory
+  mkdir("myfolder", S_IRWXU | S_IRWXG | S_IRWXO);  
+  
+  // Noncompliant: The process set 777 permissions to this file
+  chmod("myfile.txt", S_IRWXU | S_IRWXG | S_IRWXO);  
+}
+// {/fact}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of C files from the `aws_guru_c_detector_library_samples` directory to the repository.

## 📁 Files Added
- Source Folder: `aws_guru_c_detector_library_samples`
- Batch: aws-guru-c-detector-library-samples-c-batch-02
- Language: C
- Contains c files collected from the source directory

## 🔍 Changes
- Added c files from `aws_guru_c_detector_library_samples` maintaining original directory structure
- Files organized in batch 02 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `aws_guru_c_detector_library_samples`
